### PR TITLE
[AS-410][FE] Develop “Closing Meetings” Tab UI

### DIFF
--- a/src/components/ClosingMeetings.tsx
+++ b/src/components/ClosingMeetings.tsx
@@ -196,9 +196,9 @@ const ClosingMeetings = () => {
                                     <TableCell>
                                         <Tooltip title="View Recording" arrow>
                                             <Button
-                                            variant="outlined"
+                                            variant="text"
                                             sx={{}}
-                                            color="primary">
+                                            color="inherit">
                                             <VisibilityIcon />
                                             </Button>
                                         </Tooltip>
@@ -206,9 +206,9 @@ const ClosingMeetings = () => {
                                     <TableCell>
                                         <Tooltip title={recording.transcripted ? "View Transcript" : "Generate Transcript"}> 
                                             <Button
-                                            variant="outlined"
+                                            variant="text"
                                             sx={{}}
-                                            color="primary"
+                                            color="inherit"
                                             onClick={() => createTranscript(recording.id, recording.transcripted)}>
                                             {recording.transcripted ? <DescriptionIcon /> : <MicIcon />}
                                             </Button>
@@ -217,9 +217,9 @@ const ClosingMeetings = () => {
                                     <TableCell>
                                         <Tooltip title="Delete Recording" arrow>
                                             <Button
-                                            variant="outlined"
+                                            variant="text"
                                             sx={{}}
-                                            color="error"
+                                            color="inherit"
                                             onClick={() => deleteRecord(recording.id)}>
                                             <DeleteIcon />
                                             </Button>

--- a/src/components/Documents.tsx
+++ b/src/components/Documents.tsx
@@ -91,7 +91,7 @@ const Documents = () => {
     const [documentId, setDocumentId] = useState(0);
     const [draftDialogTitle, setDraftDialogTitle] = useState("");
     const [shareDialogTitle, setShareDialogTitle] = useState("");
-    const [users, setUsers] = useState<Participant[]>(Participants);
+    const [users] = useState<Participant[]>(Participants);
     const [userId, setUserId] = useState(0);
     const [authorize,setAuthorize] = useState("");
 
@@ -300,6 +300,7 @@ const Documents = () => {
                                         <Tooltip title="Preview" arrow>
                                             <Button
                                                 variant="outlined"
+                                                color="inherit"
                                                 sx={{}}
                                                 onClick={() => openDraftDocumentDialog(document.Id)} >
                                                 <VisibilityIcon />
@@ -317,7 +318,7 @@ const Documents = () => {
                                         >
                                             <Button
                                                 variant="outlined"
-                                                color="primary"
+                                                color="inherit"
                                                 onClick={() => changeDocumentStatus(document.Id)}
                                                 disabled={document.Status === Status.Released ? true: false}
                                             >
@@ -331,6 +332,7 @@ const Documents = () => {
                                         <Tooltip title="Share Document">
                                             <Button
                                                 variant="outlined"
+                                                color="inherit"
                                                 sx={{}}
                                                 onClick={() => openSharedDocumentDialog(document.Id)}>
                                                 <ShareIcon />
@@ -340,8 +342,8 @@ const Documents = () => {
                                     <TableCell>
                                         <Button
                                             variant="outlined"
+                                            color="inherit"
                                             sx={{}}
-                                            color="error"
                                             onClick={() => deleteDocument(document.Id)}>
                                             <DeleteIcon />
                                         </Button>

--- a/src/components/Tasks.tsx
+++ b/src/components/Tasks.tsx
@@ -312,15 +312,17 @@ const Task = () => {
                                     <Tooltip title="Share Task">
                                         <Button
                                         variant="outlined"
+                                        color="inherit"
                                         onClick={() => openSharedTaskDialog(task.id)}
                                         sx={{}}>
                                             <ShareIcon />
                                         </Button>
                                     </Tooltip>
                                     <Button
-                                    variant="outlined"
-                                    onClick={() => deleteTask(task.id)}
-                                    sx={{ml:2}}>
+                                        variant="outlined"
+                                        color="inherit"
+                                        onClick={() => deleteTask(task.id)}
+                                        sx={{ml:2}}>
                                         <DeleteIcon />
                                     </Button>
                                 </TableCell>


### PR DESCRIPTION
## Ticket

- [AS-410](https://www.notion.so/code-leap/1a0298c169e6808e8934c8db74e70021?v=1a0298c169e680559dc6000c8ef737ad&p=1a1298c169e6802693aec215377f2c7e&pm=s) [FE] Develop “Closing Meetings” Tab UI

## Description

Fix to Richard Poll's comment, including: 
+ Ensure that all icons are consistent in color, frame, and style across all pages, aligning with the icon style in "Closing Steps.”
+ Fix icon consistency in Closing Meeting, Task, Documents & Participants.
+ Addition: Fix "Add participant" button & its functionalities.

## Project of change

- [ ] root
- [ ] api/
- [ ] appPackage/
- [ ] build/
- [ ] devTools/
- [ ] env/
- [ ] images/
- [ ] infra/
- [ ] public/
- [x] src/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Code style update (formatting, renaming), remove unused code, or clean up code.
- [ ] Documentation update (non-code change).
- [ ] Dependency update.
- [ ] DevOps update (CI/CD, infrastructure, etc).

## How Has This Been Tested?
<img width="1899" alt="Screenshot 2025-03-11 at 11 57 25" src="https://github.com/user-attachments/assets/80ccc87b-63eb-40f5-9dfd-b2949f089c27" />

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Depend on other PRs

`N/A`