### PR TITLE
[AS-004] Develop UI in all current pages to change from @mui/material to @fluentUI/web-component

### DIFF
--- a/src/components/ClosingMeetings.tsx
+++ b/src/components/ClosingMeetings.tsx
@@ -1,309 +1,357 @@
-import {useState } from "react";
+import { useState } from "react";
 import {
-    Card, Box,
-    Table,
-    TableHead,
-    TableBody,
-    TableRow,
-    TableCell,
-    TableContainer,
-    Paper,
-    Button,
-    Dialog, 
-    DialogTitle, 
-    DialogContent, 
-    DialogActions, 
-    TextField,
-    Tooltip,
-    Typography
-} from "@mui/material";
+  Text,
+  Stack,
+  DefaultButton,
+  PrimaryButton,
+  IconButton,
+  Dialog,
+  DialogContent,
+  DialogType,
+  DialogFooter,
+  TextField,
+  TooltipHost,
+  DetailsList,
+  DetailsListLayoutMode,
+  SelectionMode,
+  IColumn,
+  mergeStyleSets
+} from "@fluentui/react";
 import {
-    Delete as DeleteIcon,
-    Visibility as VisibilityIcon,
-    Mic as MicIcon,
-    Description as DescriptionIcon,
-    Close as CloseIcon
-} from "@mui/icons-material";
+  Eye24Filled,
+  Delete24Filled,
+  Mic24Filled,
+  Document24Filled,
+} from "@fluentui/react-icons";
 
 interface Recording {
-    id: number;
-    recordingName: string;
-    date: Date;
-    transcripted : boolean;
-    transcript: string
+  id: number;
+  recordingName: string;
+  date: Date;
+  transcripted: boolean;
+  transcript: string;
 }
 
-const initialecordings: Recording[] = [
-    {id: 1, recordingName: "Closing Meeting 1", date: new Date("2024-01-01 10:00"), transcripted: false, transcript:""},
-    {id: 2, recordingName: "Closing Meeting 2", date: new Date("2024-06-15 14:00"), transcripted: false, transcript:"This is the transcript <br/>"},
-    {id: 3, recordingName: "Closing Meeting 3", date: new Date("2024-09-30 23:00"), transcripted: false, transcript:""},
-]
+const initialRecordings: Recording[] = [
+  { id: 1, recordingName: "Closing Meeting 1", date: new Date("2024-01-01 10:00"), transcripted: false, transcript: "" },
+  { id: 2, recordingName: "Closing Meeting 2", date: new Date("2024-06-15 14:00"), transcripted: false, transcript: "This is the transcript <br/>" },
+  { id: 3, recordingName: "Closing Meeting 3", date: new Date("2024-09-30 23:00"), transcripted: false, transcript: "" },
+];
+
+const useStyles = mergeStyleSets({
+    container: {
+        padding: 20, 
+        margin: 20,
+        border: '1px solid #e1e1e1',
+        borderRadius: 8
+    },
+    header: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 20,
+        marginTop:10
+    },
+    permissionButton: {
+        marginRight: 8
+    },
+    tableBody: {
+    },
+    tableCell: {
+        alignItems: 'center'
+    }
+});
 
 const ClosingMeetings = () => {
-    const [recordings, setRecordings] = useState<Recording[]>(initialecordings);
-    const [recording, setRecording] = useState<Recording>({
-        id: 0,
-        recordingName: "",
+  const [recordings, setRecordings] = useState<Recording[]>(initialRecordings);
+  const [recording, setRecording] = useState<Recording>({
+    id: 0,
+    recordingName: "",
+    date: new Date(),
+    transcripted: false,
+    transcript: ""
+  });
+
+  const [isRecordingDialogOpen, setIsRecordingDialogOpen] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isEditing, setIsEditing] = useState<number | null>(null);
+  const [editedName, setEditedName] = useState('');
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [dialogTitle, setDialogTitle] = useState('');
+  const [dialogContent, setDialogContent] = useState<React.ReactNode>(null);
+  const [dialogFooter, setDialogFooter] = useState<React.ReactNode>(null);
+
+  const toggleRecording = () => {
+    setIsRecording(!isRecording);
+    if (isRecording) {
+      const newRecord = {
+        id: recordings.length + 1,
+        recordingName: "Closing Meeting " + (recordings.length + 1),
         date: new Date(),
         transcripted: false,
-        transcript: ""
-    });
-    const [isRecordingDialogOpen, setIsRecordingDialogOpen] = useState(false);
-    const [isRecording, setIsRecording] = useState(false);
-    const [isEditing, setIsEditing] = useState(null);
-    const [editedName, setEditedName] = useState('');
-    const [isDialogOpen, setIsDialogOpen] = useState(false);
-    const [dialogTitle, setDialogTitle] = useState('');
-    const [dialogContent, setDialogContent] = useState('');
-    const [dialogAction, setDialogAction] = useState(<DialogActions></DialogActions>);
-
-    const toggleRecording = () => {
-        setIsRecording(!isRecording);
-        if(isRecording){
-            const newRecord = {
-                id: recordings.length+1,
-                recordingName: "Closing Meeting "+ (recordings.length+1),
-                date: new Date(),
-                transcripted: false,
-                transcript: ''
-            };
-
-            setRecordings([...recordings, newRecord]);
-        }
+        transcript: ''
+      };
+      setRecordings([...recordings, newRecord]);
     }
+  };
 
-    const handleEditClick = (recording: any) => {
-        setIsEditing(recording.id);
-        setEditedName(recording.recordingName);
-    };
+  const handleEditClick = (recording: Recording) => {
+    setIsEditing(recording.id);
+    setEditedName(recording.recordingName);
+  };
 
-    const handleSave = (id: any) => {
-        var record = recordings.find(rec => rec.id === id);
-        if(record){
-            const currRec = {
-                ...record,
-                recordingName: editedName,
-            };
-            setRecordings((prevRecordings) =>
-                prevRecordings.map((rec) =>
-                    rec.id === id ? currRec : rec // Replace the old recording with the updated one
-                )
-            );
-        };
-        setIsEditing(null);
-    };
-
-    const createTranscript = (id: any, transcripted: boolean) => {
-        // Update the transcripted state for the specific recording
-        setRecordings(prevRecordings =>
-            prevRecordings.map(recording =>
-                recording.id === id ? { ...recording, transcripted: true } : recording
-            )
-        );
-
-        if (transcripted){
-            openDialog();
-            var record = recordings.find(rec => rec.id === id);
-            if(record){
-                setDialogTitle(`Transcript for ${record.recordingName}`);
-                setDialogContent(`Transcript: ${record.transcript}`);
-                setDialogAction(<></>);
-
-            }
-        }
-    };
-
-    const deleteRecord = (id: any) => {
-        openDialog();
-        var record = recordings.find(rec => rec.id === id);
-            if(record){
-                setDialogTitle(`Do you want to delete the record '${record.recordingName}'`);
-                setDialogContent('');
-                setDialogAction(
-                    <DialogActions>
-                        <Button
-                            variant="contained"
-                            onClick={() => approveDeleteRecord(id)}
-                            sx={{
-                            backgroundColor:"Red",
-                            color:"white"
-                            }}
-                        >
-                            Yes
-                        </Button>
-                        <Button
-                            variant="contained"
-                            onClick={() => closeDialog()}
-                            sx={{
-                            backgroundColor:"lightgray",
-                            color:"black"
-                            }}
-                        >
-                        No
-                        </Button>
-                    </DialogActions>
-                    
-                );
-            }
-    }
-    const approveDeleteRecord = (id: any) => {
-        setRecordings((prevRecords) => prevRecords.filter((record) => record.id !== id));
-        closeDialog();
-    }
-
-    const openRecordingDialog = (id: number) => {
-        setRecording({
-            id: 0,
-            recordingName: "",
-            date: new Date(),
-            transcripted: false,
-            transcript: ""
-        });
-        var record = recordings.find((record) => record.id === id);
-        if(record){
-            setRecording({
-                id: id,
-                recordingName: record.recordingName,
-                date: record.date,
-                transcripted: record.transcripted,
-                transcript: record.transcript
-            });
-            setIsRecordingDialogOpen(true);
-            return;
-        }
-        alert("Something's wrong, please try again");
-    }
-
-    const openDialog = () => {
-        setIsDialogOpen(true);
-    }
-    const closeDialog = () => {
-        setIsDialogOpen(false);
-        setIsRecordingDialogOpen(false);
-    }
-
-    return (
-        <Card sx={{ p: 3, m: 2 }}>
-            <Box display="flex" justifyContent="space-between" alignItems="center">
-                <Box>
-                    <h1 style={{fontWeight: "bold" }}>&nbsp; Closing Meeting</h1>
-                </Box>
-                <Button 
-                    variant="contained" 
-                    onClick={toggleRecording} 
-                    sx={{ 
-                        mb: 2, 
-                        width: 200, 
-                        backgroundColor: isRecording ? "Red" : "Black", 
-                        '&:hover': !isRecording ? { backgroundColor: 'darkgray' } : { backgroundColor: 'maroon' } 
-                        }}>
-                        {isRecording ? "Stop Recording" : "Start Recording"}
-                </Button>
-            </Box>
-            <TableContainer component={Paper} sx={{mt:2}}>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>Recording Name</TableCell>
-                            <TableCell>Date</TableCell>
-                            <TableCell>Actions</TableCell>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {
-                            recordings.map((recording) => (
-                                <TableRow key={recording.id}>
-                                    <TableCell>
-                                        {isEditing === recording.id ? (
-                                            <TextField
-                                                value={editedName}
-                                                onChange={(e) => setEditedName(e.target.value)}
-                                                onBlur={() => handleSave(recording.id)} // Save on blur
-                                                onKeyDown={(e) => {
-                                                    if (e.key === 'Enter') {
-                                                        handleSave(recording.id); // Save on Enter
-                                                    }
-                                                }}
-                                                autoFocus
-                                            />
-                                        ) : (
-                                            <span onClick={() => handleEditClick(recording)}>
-                                                {recording.recordingName}
-                                            </span>
-                                        )}
-                                    </TableCell>
-                                    <TableCell>{recording.date.toLocaleString()}</TableCell>
-                                    <TableCell>
-                                        <Tooltip title="View Recording" arrow>
-                                            <Button
-                                            variant="text"
-                                            sx={{}}
-                                            color="inherit"
-                                            onClick={() => openRecordingDialog(recording.id)}>
-                                            <VisibilityIcon />
-                                            </Button>
-                                        </Tooltip>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Tooltip title={recording.transcripted ? "View Transcript" : "Generate Transcript"}> 
-                                            <Button
-                                            variant="text"
-                                            sx={{}}
-                                            color="inherit"
-                                            onClick={() => createTranscript(recording.id, recording.transcripted)}>
-                                            {recording.transcripted ? <DescriptionIcon /> : <MicIcon />}
-                                            </Button>
-                                        </Tooltip>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Tooltip title="Delete Recording" arrow>
-                                            <Button
-                                            variant="text"
-                                            sx={{}}
-                                            color="inherit"
-                                            onClick={() => deleteRecord(recording.id)}>
-                                            <DeleteIcon />
-                                            </Button>
-                                        </Tooltip>
-                                    </TableCell>
-                                </TableRow>
-                            ))
-                        }
-                    </TableBody>
-                </Table>
-            </TableContainer>
-            <Dialog open={isRecordingDialogOpen} onClose={closeDialog} fullWidth>
-                <DialogTitle>
-                    <Box display="flex" justifyContent="space-between" alignItems="center">
-                        <Typography variant="h6" sx={{fontWeight: 'Bold'}}>Record of {recording.recordingName}</Typography>
-                        <Button onClick={closeDialog} color="inherit">
-                            <CloseIcon />
-                        </Button>
-                    </Box>
-                </DialogTitle>
-                <DialogContent>
-                <DialogContent dividers style={{ textAlign: 'center', height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: '#f5f5f5' }}>
-                    <Typography variant="h6" style={{ fontWeight: 'normal' }}>
-                        Preview of  {recording.recordingName}
-                    </Typography>
-                    <Box position="absolute" style={{ opacity: 0.1, fontSize: '4rem', color: 'gray' }}>
-                        RECORDING HERE
-                    </Box>
-                    </DialogContent>
-                </DialogContent>
-            </Dialog>
-            <Dialog open={isDialogOpen} onClose={closeDialog} fullWidth>
-                <DialogTitle sx={{fontWeight: 'Bold'}}>{dialogTitle}</DialogTitle>
-                <DialogContent>
-                    {dialogContent}
-                </DialogContent>
-                {dialogAction}
-            </Dialog>
-        </Card>
+  const handleSave = (id: number) => {
+    const updatedRecordings = recordings.map((rec) =>
+      rec.id === id ? { ...rec, recordingName: editedName } : rec
     );
-}
+    setRecordings(updatedRecordings);
+    setIsEditing(null);
+  };
 
-// Correctly export the component
+  const createTranscript = (id: number, transcripted: boolean) => {
+    setRecordings((prev) =>
+      prev.map((recording) =>
+        recording.id === id ? { ...recording, transcripted: true } : recording
+      )
+    );
+
+    if (transcripted) {
+      openDialog();
+      const record = recordings.find((rec) => rec.id === id);
+      if (record) {
+        setDialogTitle(`Transcript for ${record.recordingName}`);
+        setDialogContent(<Text>Transcript: {record.transcript}</Text>);
+        setDialogFooter(null);
+      }
+    }
+  };
+
+  const deleteRecord = (id: number) => {
+    openDialog();
+    const record = recordings.find((rec) => rec.id === id);
+    if (record) {
+      setDialogTitle(`Do you want to delete the record '${record.recordingName}'`);
+      setDialogContent(null);
+      setDialogFooter(
+        <DialogFooter>
+          <PrimaryButton text="Yes" onClick={() => approveDeleteRecord(id)} styles={{ root: { backgroundColor: 'red', color: 'white' } }} />
+          <DefaultButton text="No" onClick={closeDialog} />
+        </DialogFooter>
+      );
+    }
+  };
+
+  const approveDeleteRecord = (id: number) => {
+    setRecordings((prevRecords) => prevRecords.filter((record) => record.id !== id));
+    closeDialog();
+  };
+
+  const openRecordingDialog = (id: number) => {
+    const record = recordings.find((record) => record.id === id);
+    if (record) {
+      setRecording(record);
+      setIsRecordingDialogOpen(true);
+    } else {
+      alert("Something's wrong, please try again");
+    }
+  };
+
+  const openDialog = () => {
+    setIsDialogOpen(true);
+  };
+
+  const closeDialog = () => {
+    setIsDialogOpen(false);
+    setIsRecordingDialogOpen(false);
+  };
+
+  const columns: IColumn[] = [
+    {
+      key: 'column1',
+      name: 'Recording Name',
+      fieldName: 'recordingName',
+      minWidth: 150,
+      maxWidth: 600,
+      isResizable: true,
+      isMultiline: true,
+      onRender: (item: Recording) => (
+        isEditing === item.id ? (
+          <TextField
+            value={editedName}
+            onChange={(e, newValue) => setEditedName(newValue || '')}
+            onBlur={() => handleSave(item.id)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter'){
+                e.preventDefault();
+                e.stopPropagation()
+                handleSave(item.id);
+              } 
+            }}
+            style={{fontSize:14}}
+          />
+        ) : (
+          <span onClick={() => handleEditClick(item)} style={{ cursor: 'pointer', fontSize:14 }}>{item.recordingName}</span>
+        )
+      )
+    },
+    {
+      key: 'column2',
+      name: 'Date',
+      fieldName: 'date',
+      minWidth: 150,
+      isResizable: true,
+      onRender: (item: Recording) => <span style={{fontSize:14}}>{item.date.toLocaleString()}</span>
+    },
+    {
+      key: 'column3',
+      name: 'Actions',
+      minWidth: 300,
+      isResizable: true,
+      onRender: (item: Recording) => (
+        <Stack horizontal tokens={{ childrenGap: 20 }}>
+          <TooltipHost content="View Recording">
+            <IconButton
+              iconProps={{ iconName: 'View' }}
+              onClick={() => openRecordingDialog(item.id)}
+              style={{color:"black"}}
+            >
+              <Eye24Filled />
+            </IconButton>
+          </TooltipHost>
+          <TooltipHost content={item.transcripted ? "View Transcript" : "Generate Transcript"}>
+            <IconButton
+              iconProps={{ iconName: 'Microphone' }}
+              onClick={() => createTranscript(item.id, item.transcripted)}
+              style={{color:"black"}}
+            >
+              {item.transcripted ? <Document24Filled /> : <Mic24Filled />}
+            </IconButton>
+          </TooltipHost>
+          <TooltipHost content="Delete Recording">
+            <IconButton
+              iconProps={{ iconName: 'Delete' }}
+              onClick={() => deleteRecord(item.id)}
+              style={{color:"black"}}
+            >
+              <Delete24Filled />
+            </IconButton>
+          </TooltipHost>
+        </Stack>
+      )
+    }
+  ];
+
+  return (
+    <Stack className={useStyles.container}>
+      <Stack horizontal horizontalAlign="space-between" className={useStyles.header}>
+        <Text variant="xLargePlus" styles={{ root: { fontWeight: 'bold'} }}>Closing Meeting</Text>
+        <PrimaryButton
+          text={isRecording ? "Stop Recording" : "Start Recording"}
+          onClick={toggleRecording}
+          styles={{
+            root: {
+              width: 250,
+              backgroundColor: isRecording ? 'red' : 'black',
+              fontSize:18,
+              fontWeight:"bold"
+            },
+            rootHovered: {
+              backgroundColor: isRecording ? 'maroon' : 'darkgray'
+            },
+            label: {
+              fontWeight:"bold", fontSize:17
+            }
+          }}
+        />
+      </Stack>
+
+      <DetailsList
+        items={recordings}
+        columns={columns}
+        setKey="set"
+        layoutMode={DetailsListLayoutMode.justified}
+        selectionMode={SelectionMode.none}
+        styles={{ 
+            root: { 
+                marginTop: 16,
+                width: "100%"
+            },
+            contentWrapper: {
+                display: 'flex',
+                flexGrow: 1
+            }
+        }}
+      />
+
+        {/* Recording Preview Dialog */}
+        <Dialog
+        hidden={!isRecordingDialogOpen}
+        onDismiss={closeDialog}
+        dialogContentProps={{
+            type: DialogType.normal,
+            title: `Record of ${recording.recordingName}`,
+            showCloseButton: true
+        }}
+        minWidth={600}
+        styles={{
+            main: {
+            maxWidth: 800,
+            },
+        }}
+        >
+        <Stack
+            styles={{
+            root: {
+                textAlign: 'center',
+                height: '300px',
+                width: '100%',
+                justifyContent: 'center',
+                backgroundColor: '#f5f5f5',
+                position: 'relative',
+                padding: 16,
+            },
+            }}
+        >
+            <Text variant="xxLarge">Preview of {recording.recordingName}</Text>
+            <Text
+            variant="xxLarge"
+            styles={{
+                root: {
+                position: 'absolute',
+                opacity: 0.1,
+                fontSize: '4rem',
+                color: 'gray',
+                },
+            }}
+            >
+            RECORDING HERE
+            </Text>
+        </Stack>
+        </Dialog>
+
+
+        {/* General Dialog */}
+        <Dialog
+        hidden={!isDialogOpen}
+        onDismiss={closeDialog}
+        minWidth={600}
+        styles={{
+            main: {
+            maxWidth: 800,
+            },
+        }}
+        >
+        <DialogContent
+            title={dialogTitle}
+            showCloseButton
+            onDismiss={closeDialog}
+        >
+            {dialogContent}
+            {dialogFooter}
+        </DialogContent>
+        </Dialog>
+    </Stack>
+  );
+};
+
 export default ClosingMeetings;

--- a/src/components/ClosingMemo.tsx
+++ b/src/components/ClosingMemo.tsx
@@ -1,190 +1,252 @@
-import {useState} from "react";
+import { useState } from "react";
 import {
-    Box,
-    Button,
-    Card,
-    Dialog,
-    DialogContent,
-    DialogTitle,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableHead,
-    TableRow,
-    Tooltip,
-    Typography
-} from "@mui/material";
+  Stack,
+  DefaultButton,
+  PrimaryButton,
+  IconButton,
+  Panel,
+  PanelType,
+  Text,
+  TooltipHost,
+  DetailsList,
+  DetailsListLayoutMode,
+  IColumn
+} from "@fluentui/react";
 import {
-    Description as DescriptionIcon,
-    Visibility as VisibilityIcon,
-    Download as DownloadIcon,
-    Delete as DeleteIcon,
-    Close as CloseIcon
-} from '@mui/icons-material';
-import {User, initialUsers} from './Participants';
-import {Task, initialTasks} from './Tasks';
-import {initialDocuments, Document} from './Documents';
-import {Step, initialSteps} from './ClosingSteps';
+  Document20Filled,
+  Eye20Filled,
+  ArrowDownload20Filled,
+  Delete20Filled,
+  Dismiss20Filled
+} from "@fluentui/react-icons";
+
+import { User, initialUsers } from './Participants';
+import { Task, initialTasks } from './Tasks';
+import { initialDocuments, Document } from './Documents';
+import { Step, initialSteps } from './ClosingSteps';
 
 interface Memo {
-    id: number;
-    createdDate: Date;
-    description: string;
-    participants: User[]
-    tasks: Task[]
-    documents: Document[]
-    steps: Step[]
+  id: number;
+  createdDate: Date;
+  description: string;
+  participants: User[];
+  tasks: Task[];
+  documents: Document[];
+  steps: Step[];
 }
 
-const initialMemos: Memo[] = [
-]
+const initialMemos: Memo[] = [];
 
 const ClosingMemo = () => {
-    const [memos, setMemos] = useState(initialMemos);
-    const [memoId, setMemoId] = useState(0);
-    const [memoDate, setMemoDate] = useState(new Date());
-    const [memoParticipants, setMemoParticipants] = useState<User[]>();
-    const [memoTasks, setMemoTasks] = useState<Task[]>();
-    const [memoClosingStep, setMemoClosingStep] = useState<Step[]>();
-    const [memoDocuments, setMemoDocuments] = useState<Document[]>();
-    const [users] = useState<User[]>(initialUsers);
-    const [tasks] = useState<Task[]>(initialTasks);
-    const [documents] = useState<Document[]>(initialDocuments)
-    const [steps] = useState<Step[]>(initialSteps)
-    const [isViewDialogOpen, setIsViewDialogOpen] = useState(false);
+  const [memos, setMemos] = useState(initialMemos);
+  const [memoId, setMemoId] = useState(0);
+  const [memoDate, setMemoDate] = useState(new Date());
+  const [memoParticipants, setMemoParticipants] = useState<User[]>();
+  const [memoTasks, setMemoTasks] = useState<Task[]>();
+  const [memoClosingStep, setMemoClosingStep] = useState<Step[]>();
+  const [memoDocuments, setMemoDocuments] = useState<Document[]>();
 
-    const createMemo = () => {
-        var randomNumOfParticipants = Math.floor(Math.random() * (8)) + 1
-        const newMemo: Memo = {
-            id: memos.length + 1,
-            createdDate: new Date(),
-            description: "New Memo",
-            participants: users.sort(() => 0.5 - Math.random()).slice(0, randomNumOfParticipants),
-            tasks: tasks.sort(() => 0.5 - Math.random()).slice(0,2),
-            documents: documents.sort(() => 0.5 - Math.random()).slice(0,3),
-            steps: steps.sort(() => 0.5 - Math.random()).slice(0,4)
-        }
-        setMemos([...memos, newMemo]);
+  const [users] = useState<User[]>(initialUsers);
+  const [tasks] = useState<Task[]>(initialTasks);
+  const [documents] = useState<Document[]>(initialDocuments);
+  const [steps] = useState<Step[]>(initialSteps);
+
+  const [isViewDialogOpen, setIsViewDialogOpen] = useState(false);
+
+  const createMemo = () => {
+    const randomNumOfParticipants = Math.floor(Math.random() * 8) + 1;
+    const newMemo: Memo = {
+      id: memos.length + 1,
+      createdDate: new Date(),
+      description: "New Memo",
+      participants: users.sort(() => 0.5 - Math.random()).slice(0, randomNumOfParticipants),
+      tasks: tasks.sort(() => 0.5 - Math.random()).slice(0, 2),
+      documents: documents.sort(() => 0.5 - Math.random()).slice(0, 3),
+      steps: steps.sort(() => 0.5 - Math.random()).slice(0, 4)
+    };
+    setMemos([...memos, newMemo]);
+  };
+
+  const deleteMemo = (id: number) => {
+    setMemos(memos => memos.filter(memo => memo.id !== id));
+  };
+
+  const openViewMemo = (id: number) => {
+    setMemoId(0);
+    setMemoDate(new Date("0001-01-01 00:00:00"));
+    setMemoParticipants([]);
+    setMemoTasks([]);
+    setMemoDocuments([]);
+    setMemoClosingStep([]);
+
+    const memo = memos.find(memo => memo.id === id);
+    if (memo) {
+      setMemoId(id);
+      setMemoDate(memo.createdDate);
+      setMemoParticipants(memo.participants);
+      setMemoTasks(memo.tasks);
+      setMemoDocuments(memo.documents);
+      setMemoClosingStep(memo.steps);
+      setIsViewDialogOpen(true);
+      return;
     }
+    alert("Something's wrong, please try again");
+  };
 
-    const deleteMemo = (id: number) => {
-        setMemos(memos => memos.filter(memo => memo.id !== id));
+  const closeViewMemo = () => {
+    setIsViewDialogOpen(false);
+  };
+
+  const downloadMemo = (id:number) => {
+    const memo = memos.find(memo => memo.id === id);
+    if (memo) {
+      setMemoId(id);
+      setMemoDate(memo.createdDate);
+      setMemoParticipants(memo.participants);
+      setMemoTasks(memo.tasks);
+      setMemoDocuments(memo.documents);
+      setMemoClosingStep(memo.steps);
+      setIsViewDialogOpen(true);
+      return;
     }
+    const memoContent = `
+        Closing Memo Id: ${memoId}
+        Date: ${memoDate.toLocaleString()}
+        Created By: ${memoParticipants?.map(user => user.name).slice(0, 1)} 
+        Number of participants: ${memoParticipants?.length}
+        Participants: ${memoParticipants?.map(user => user.name).join(', ')}
+        Documents: ${memoDocuments?.map(doc => doc.DocumentName).join(', ')}
+        Closing Steps: ${memoClosingStep?.map(step => step.stepDescription).join(', ')}
+        `;
 
-    const openViewMemo = (id: number) =>{
-        setMemoId(0);
-        setMemoDate(new Date("0001-01-01 00:00:00"));
-        setMemoParticipants([]);
-        setMemoTasks([]);
-        setMemoDocuments([]);
-        setMemoClosingStep([]);
-        var memo = memos.find((memo) => memo.id == id);
-        if(memo){
-            setMemoId(id);
-            setMemoDate(memo.createdDate);
-            setMemoParticipants(memo.participants);
-            setMemoTasks(memo.tasks);
-            setMemoDocuments(memo.documents);
-            setMemoClosingStep(memo.steps);
-            setIsViewDialogOpen(true);
-            return;
-        }
-        alert("Something's wrong, please try again");
+        // Tạo một blob từ content
+    const blob = new Blob([memoContent], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+
+    // Tạo thẻ <a> để trigger download
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `ClosingMemo_${memoId}.txt`;
+    document.body.appendChild(link);
+    link.click();
+
+    // Cleanup
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }
+
+  const columns: IColumn[] = [
+    {
+      key: 'column1',
+      name: 'Date',
+      fieldName: 'createdDate',
+      minWidth: 150,
+      maxWidth: 600,
+      isResizable:true,
+      isMultiline:true,
+      onRender: (item: Memo) => (
+        <Text style={{fontSize:14}}>{item.createdDate.toLocaleString()}</Text>
+      )
+    },
+    {
+      key: 'column2',
+      name: 'Action',
+      minWidth: 150,
+      isResizable:true,
+      onRender: (item: Memo) => (
+        <Stack horizontal tokens={{ childrenGap: 8 }} horizontalAlign="start">
+          <TooltipHost content="Preview Memo">
+            <IconButton
+              iconProps={{ iconName: 'View' }}
+              onClick={() => openViewMemo(item.id)}
+              style={{color:"#000000"}}
+            >
+              <Eye20Filled />
+            </IconButton>
+          </TooltipHost>
+
+          <TooltipHost content="Download Memo">
+          <IconButton
+                iconProps={{ iconName: 'Download' }}
+                onClick={() => downloadMemo(memoId +1)} // ✅ Pass cả memo vào
+                style={{color:"#000000"}}
+            >
+              <ArrowDownload20Filled />
+            </IconButton>
+          </TooltipHost>
+
+          <TooltipHost content="Delete Memo">
+            <IconButton
+              iconProps={{ iconName: 'Delete' }}
+              onClick={() => deleteMemo(item.id)}
+              style={{color:"#000000"}}
+            >
+              <Delete20Filled />
+            </IconButton>
+          </TooltipHost>
+        </Stack>
+      )
     }
+  ];
 
-    const closeViewMemo = () => {
-        setIsViewDialogOpen(false);
-    }
+  return (
+    <Stack tokens={{ childrenGap: 16 }} styles={{ root: { padding: 20, margin: 10, border: '1px solid #eee', borderRadius: 8, boxShadow: '0 2px 5px rgba(0,0,0,0.1)' } }}>
+      <Stack horizontal horizontalAlign="space-between" verticalAlign="center">
+        <Text variant="xLargePlus" styles={{ root: { fontWeight: 'bold' } }}>
+          Closing Memos
+        </Text>
+        <PrimaryButton
+          text="Generate Memo"
+          onClick={createMemo}
+          styles={{
+            root: { width: 250, backgroundColor: 'black', fontWeight: 'bold', fontSize:18 },
+            rootHovered: { backgroundColor: 'darkgray' }
+          }}
+          iconProps={{ iconName: 'Document' }}
+        >
+          <Document20Filled />
+        </PrimaryButton>
+      </Stack>
 
-    return (
-        <Card sx={{ p: 3, m: 2 }}>
-            <Box justifyContent="space-between" alignItems="center">
-                <Box display="flex" justifyContent="space-between" alignItems="center">
-                    <h1 style={{fontWeight: "bold" }}>
-                        Closing Memos
-                    </h1>
-                    <Button 
-                        variant="contained" 
-                        onClick={createMemo} 
-                        sx={{ 
-                            mb: 2, 
-                            width: 200, 
-                            backgroundColor: "black", 
-                            fontWeight:"bold", '&:hover': { backgroundColor: 'darkgray' }}}>
-                        <DescriptionIcon />&nbsp;Generate Memo
-                    </Button>
-                </Box>
-                <Box>
-                    <TableContainer>
-                        <Table>
-                            <TableHead>
-                                <TableCell>Date</TableCell>
-                                <TableCell sx={{display:"flex", justifyContent:"flex-end"}}>Action</TableCell>
-                            </TableHead>
-                            <TableBody>
-                                {memos.map((memo) => (
-                                    <TableRow key={memo.id} sx={{maxWidth:100}}>
-                                        <TableCell>
-                                            {memo.createdDate.toLocaleString()}
-                                        </TableCell>
-                                        <TableCell sx={{display:"flex", justifyContent:"flex-end"}}>
-                                            <Tooltip title="Preview Memo">
-                                                <Button
-                                                    variant="text"
-                                                    sx={{}}
-                                                    color="inherit"
-                                                    onClick={() => openViewMemo(memo.id)}>
-                                                    <VisibilityIcon />
-                                                </Button>
-                                            </Tooltip>
-                                            <Tooltip title="Download Memo" arrow>
-                                                <Button
-                                                    variant="text"
-                                                    color="inherit">
-                                                    <DownloadIcon />
-                                                </Button>
-                                            </Tooltip>
-                                            <Tooltip title="Delete Memo" arrow>
-                                                <Button
-                                                variant="text"
-                                                sx={{}}
-                                                color="inherit"
-                                                onClick={() => deleteMemo(memo.id)}>
-                                                <DeleteIcon />
-                                                </Button>
-                                            </Tooltip>
-                                        </TableCell>
-                                    </TableRow>
-                                ))}
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
-                </Box>
-            </Box>
-            <Dialog open={isViewDialogOpen} onClose={closeViewMemo} fullWidth>
-                <DialogTitle display="flex" justifyContent="space-between" alignItems="center">
-                    <Typography variant="h6" sx={{fontWeight: 'Bold'}}>Closing Memo Preview</Typography>
-                    <Button onClick={closeViewMemo} color="inherit">
-                        <CloseIcon />
-                    </Button>
-                </DialogTitle>
-                <DialogContent>
-                    <Typography variant="body1" sx={{ fontFamily: 'Courier New, sans-serif', fontSize: '16px', fontWeight: 'bold' }}>
-                    <p>
-                        Closing Memo Id: {memoId}<br/>
-                        Date: {memoDate.toLocaleString()}<br/>
-                        Created By: {memoParticipants?.map(user=> user.name).slice(0,1)} <br/><br/>
-                        Number of participants: {memoParticipants?.length}<br/>
-                        Participants: {memoParticipants?.map(user=> user.name).join(', ')}<br/><br/>
-                        {/* Tasks: {memoTasks?.map(task => task.name).join(', ')}<br/><br/> */}
-                        Documents: {memoDocuments?.map(doc => doc.DocumentName).join(', ')}<br/><br/>
-                        Closing Steps: {memoClosingStep?.map(step => step.stepDescription).join(', ')}<br/><br/>
-                    </p>
-                    </Typography>
-                </DialogContent>
-            </Dialog>
-        </Card>
-    );
-}
+      <DetailsList
+        items={memos}
+        columns={columns}
+        layoutMode={DetailsListLayoutMode.justified}
+        selectionPreservedOnEmptyClick={true}
+        styles={{ root: { marginTop: 16 } }}
+      />
+
+    <Panel
+    isOpen={isViewDialogOpen}
+    onDismiss={closeViewMemo}
+    type={PanelType.medium}
+    isLightDismiss={true} // ✅ thêm vào để cho phép click ra ngoài mới đóng Panel
+    onRenderNavigation={() => (
+        <Stack horizontal horizontalAlign="space-between" verticalAlign="center" styles={{ root: { padding: '10px 16px' } }}>
+        <Text variant="large" styles={{ root: { fontWeight: 'bold' } }}>
+            Closing Memo Preview
+        </Text>
+        <IconButton onClick={closeViewMemo} iconProps={{ iconName: 'Cancel' }}>
+            <Dismiss20Filled />
+        </IconButton>
+        </Stack>
+    )}
+    >
+    <Text variant="mediumPlus" styles={{ root: { fontFamily: 'Courier New, sans-serif', fontWeight: 'bold' } }}>
+        <p>
+        Closing Memo Id: {memoId}<br />
+        Date: {memoDate.toLocaleString()}<br />
+        Created By: {memoParticipants?.map(user => user.name).slice(0, 1)} <br /><br />
+        Number of participants: {memoParticipants?.length}<br />
+        Participants: {memoParticipants?.map(user => user.name).join(', ')}<br /><br />
+        Documents: {memoDocuments?.map(doc => doc.DocumentName).join(', ')}<br /><br />
+        Closing Steps: {memoClosingStep?.map(step => step.stepDescription).join(', ')}<br /><br />
+        </p>
+    </Text>
+    </Panel>
+
+    </Stack>
+  );
+};
+
 export default ClosingMemo;

--- a/src/components/Documents.tsx
+++ b/src/components/Documents.tsx
@@ -1,35 +1,40 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import {
-    Card, Box,
-    TableContainer,
-    Table,
-    TableCell,
-    TableHead,
-    TableBody,
-    TableRow,
-    Paper,
-    Button,
-    Avatar,
-    Dialog,
-    DialogTitle,
-    DialogActions,
-    DialogContent,
-    Typography,
-    Tooltip,
-    TextField,
-    Select,
-    MenuItem
-} from "@mui/material";
+  Button,
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogActions,
+  DialogContent,
+  Input,
+  Dropdown,
+  Option,
+} from "@fluentui/react-components";
 import {
-    Visibility as VisibilityIcon,
-    Share as ShareIcon,    
-    Delete as DeleteIcon,
-    Close as CloseIcon,
-    PersonRemove as PersonRemoveIcon, 
-    TaskAlt as TaskAltIcon,
-    Create as CreateIcon,
-    OpenInNew as OpenInNewIcon,
-} from "@mui/icons-material";
+  Text,
+  TextField,
+  Stack,
+  Persona,
+  DetailsList,
+  DetailsListLayoutMode,
+  SelectionMode,
+  CommandBar,
+  mergeStyleSets,
+  PrimaryButton,
+  IColumn,
+  Label
+} from "@fluentui/react";
+import {
+    CheckmarkCircle24Regular,
+    Delete24Filled,
+    Dismiss24Regular,
+    Eye24Filled,
+    Open24Filled,
+    Pen24Filled,
+    PersonDelete24Filled,
+    Share24Regular,
+  } from "@fluentui/react-icons";
 import {User, initialUsers} from "./Participants";
 
 enum Status {
@@ -62,526 +67,546 @@ export const initialDocuments: Document[] = [
     {Id: 5,DocumentName:"Crew Transfer Agreement", Category:"HR", SharedWith:[{UserId:7,Authorize:"Needs to Sign"},{UserId:8,Authorize:"Needs to View"}],CreationDate: new Date("2023-05-25 10:00"), LastEdited: new Date("2023-06-08 10:00"), Status: Status.Signed},
 ]
 
-const Documents = () => { 
-    const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
-    const [isDraftDialogOpen, setIsDraftDialogOpen] = useState(false);
-    const [isSharedDialogOpen, setIsSharedDialogOpen] = useState(false);
-    const [newTitle, setNewTitle] = useState("");
-    const [newCategory, setNewCategory] = useState("");
-    const [newURL, setNewURL] = useState("");
-    const [documents, setDocuments] = useState(initialDocuments);
-    const [documentId, setDocumentId] = useState(0);
-    const [draftDialogTitle, setDraftDialogTitle] = useState("");
-    const [shareDialogTitle, setShareDialogTitle] = useState("");
-    const [users] = useState<User[]>(initialUsers);
-    const [userId, setUserId] = useState(0);
-    const [authorize,setAuthorize] = useState("");
-    const [documentError, setDocumentError] = useState({
-        title: false,
-        url: false,
-        category: false
-    });
-    const [documentErrorMessage, setDocumentErrorMessage] = useState({
+const useStyles = mergeStyleSets({
+    container: {
+        padding: 20,
+        margin: 20,
+        border: '1px solid #e1e1e1',
+        borderRadius: 8
+    },
+    header: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 20
+    },
+    permissionButton: {
+        marginRight: 8
+    },
+    tableBody: {
+    },
+    tableCell: {
+        alignItems: 'center'
+    }
+});
+
+const Documents = () => {
+  const [documents, setDocuments] = useState<Document[]>(initialDocuments);
+  const [users, setUsers] = useState<User[]>(initialUsers);
+
+  const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+  const [isSharedDialogOpen, setIsSharedDialogOpen] = useState(false);
+  const [isDraftDialogOpen, setIsDraftDialogOpen] = useState(false);
+
+  const [newTitle, setNewTitle] = useState("");
+  const [newURL, setNewURL] = useState("");
+  const [newCategory, setNewCategory] = useState<string>("");
+
+  const [documentId, setDocumentId] = useState<number>(0);
+  const [draftDialogTitle, setDraftDialogTitle] = useState("");
+  const [shareDialogTitle, setShareDialogTitle] = useState("");
+
+  const [documentError, setDocumentError] = useState({
+    title: false,
+    url: false,
+    category: false,
+  });
+  const [documentErrorMessage, setDocumentErrorMessage] = useState({
+    title: "",
+    url: "",
+    category: "",
+  });
+
+  const [userId, setUserId] = useState(0);
+  const [authorize, setAuthorize] = useState("");
+
+  const getUser = (userId: number): User | undefined => {
+    return users.find((u) => u.id === userId);
+  };
+
+  const openAddDocumentDialog = () => setIsAddDialogOpen(true);
+  const openDraftDocumentDialog = (id:number) => {
+    const doc = documents.find((d) => d.Id === id);
+    setDraftDialogTitle(doc?.DocumentName || "");
+    setIsDraftDialogOpen(true);
+  };
+  const openSharedDocumentDialog = (id:number) => {
+    const doc = documents.find((d) => d.Id === id);
+    setShareDialogTitle(doc?.DocumentName || "");
+    setDocumentId(id);
+    setIsSharedDialogOpen(true);
+  };
+  const closeDialog = () => {
+    setIsAddDialogOpen(false);
+    setIsSharedDialogOpen(false);
+    setIsDraftDialogOpen(false);
+    setDocumentErrorMessage({
         title: "",
         url: "",
-        category: ""
+        category: "",
     });
-    const [shareDocumentError, setShareDocumentError] = useState({
-        recipient: false,
-        action: false,
-    });
-    const [shareDocumentErrorMessage, setShareDocumentErrorMessage] = useState({
-        recipient:"",
-        action:""
-    })
+  };
 
-    const getUser = (id:number) => {
-        var result = users.find((user) => user.id === id);
-        if(result){
-            return result;
-        }
+  const addNewDocument = () => {
+    let hasError = false;
+    const errors = { title: false, url: false, category: false };
+    const errorMessages = { title: "", url: "", category: "" };
+
+    if (!newTitle) {
+      errors.title = true;
+      errorMessages.title = "Title is required.";
+      hasError = true;
     }
-    const getStatusColors = (status: Status) => {
-        switch (status) {
-            case Status.Draft:
-                return { backgroundColor: "#fef08a", textColor: "#854D0E" };
-            case Status.Approved:
-                return { backgroundColor: "#bfdbfe", textColor: "#1e40af" };
-            case Status.Released:
-                return { backgroundColor: "#e9d5ff", textColor: "#6b21a8" };
-            case Status.Signed:
-                return { backgroundColor: "#bbf7d0", textColor: "#166534" };
-            default:
-                return { backgroundColor: "#ffffff", textColor: "#000000" }; // Default colors
-        }
+    if (!newURL) {
+      errors.url = true;
+      errorMessages.url = "URL is required.";
+      hasError = true;
+    }
+    if (!newCategory) {
+      errors.category = true;
+      errorMessages.category = "Category is required.";
+      hasError = true;
+    }
+
+    setDocumentError(errors);
+    setDocumentErrorMessage(errorMessages);
+
+    if (hasError) return;
+
+    const newDoc: Document = {
+      Id: documents.length + 1,
+      DocumentName: newTitle,
+      Category: newCategory,
+      SharedWith: [],
+      CreationDate: new Date(),
+      LastEdited: new Date(),
+      Status: Status.Draft,
     };
 
-    const getDocument = (id: number) => {
-        return documents.find((doc) => doc.Id === id);
-    }
+    setDocuments([...documents, newDoc]);
+    setNewTitle("");
+    setNewURL("");
+    setNewCategory("");
+    closeDialog();
+  };
 
-    const openAddDocumentDialog = () => {
-        setIsAddDialogOpen(true);
-    }
+  const deleteDocument = (id: number) => {
+    setDocuments(documents.filter((doc) => doc.Id !== id));
+  };
 
-    const openDraftDocumentDialog = (docId: number) => {
-        var result = documents.find((doc) => doc.Id === docId);
-        if(result){
-            setIsDraftDialogOpen(true);
-            setDraftDialogTitle(result.DocumentName);
+  const changeDocumentStatus = (id: number) => {
+    setDocuments(
+      documents.map((doc) => {
+        if (doc.Id === id) {
+          let nextStatus = doc.Status;
+          if (doc.Status === Status.Draft) nextStatus = Status.Approved;
+          else if (doc.Status === Status.Approved) nextStatus = Status.Signed;
+          else if (doc.Status === Status.Signed) nextStatus = Status.Released;
+          return { ...doc, Status: nextStatus };
         }
-    }
-
-    const openSharedDocumentDialog = (docId: number) => {
-        var result = documents.find((doc) => doc.Id === docId);
-        if(result){
-            setUserId(0);
-            setAuthorize("");
-            setIsSharedDialogOpen(true);
-            setShareDialogTitle(result.DocumentName);
-            setDocumentId(docId);
-        }
-    }
-
-    const closeDialog = () => {
-        setIsAddDialogOpen(false);
-        setIsDraftDialogOpen(false);
-        setIsSharedDialogOpen(false);
-    }
-
-    const addShareRecipient = () => {
-        setShareDocumentError({recipient:false, action: false});
-        setShareDocumentErrorMessage({recipient:"", action:""});
-
-        let hasError = false;
-
-        if(!userId){
-            setShareDocumentErrorMessage(prev => ({ ...prev, recipient: "This field is required" }));
-            setShareDocumentError(prev => ({ ...prev, recipient: true }));
-            hasError = true;
-        } if (!authorize){
-            setShareDocumentErrorMessage(prev => ({ ...prev, action: "This field is required" }));
-            setShareDocumentError(prev => ({ ...prev, action: true }));
-            hasError = true;
-        }
-        if(hasError) return;
-
-        const newShareRecipient = {
-            UserId: userId,
-            Authorize: authorize
-        };
-
-        setUserId(0);
-        setAuthorize("");
-        setDocuments(prevDocuments => 
-            prevDocuments.map(doc => {
-                if (doc.Id === documentId) {
-                    return {
-                        ...doc,
-                        SharedWith: [...doc.SharedWith, newShareRecipient] // Create a new array with the new recipient added
-                    };
-                }
-                return doc; // Return the document unchanged if it doesn't match
-            })
-        );
-    }
-
-    const addNewDocument = () => {
-        // Reset error states
-        setDocumentError({ title: false, url: false, category: false });
-        setDocumentErrorMessage({ title: "", url: "", category: "" });
-    
-        // Validation
-        let hasError = false;
-    
-        if (!newTitle.trim()) {
-            setDocumentErrorMessage(prev => ({ ...prev, title: "This field is required" }));
-            setDocumentError(prev => ({ ...prev, title: true }));
-            hasError = true;
-        }
-        if (!newURL.trim()) {
-            setDocumentErrorMessage(prev => ({ ...prev, url: "This field is required" }));
-            setDocumentError(prev => ({ ...prev, url: true }));
-            hasError = true;
-        }
-        if (!newCategory.trim()) {
-            setDocumentErrorMessage(prev => ({ ...prev, category: "This field is required" }));
-            setDocumentError(prev => ({ ...prev, category: true }));
-            hasError = true;
-        }
-    
-        if (hasError) return; // Stop execution if there are errors
-    
-        const newDocument = {
-            Id: documents.length + 1,
-            DocumentName: newTitle,
-            Category: newCategory,
-            SharedWith: [],
-            CreationDate: new Date(),
-            LastEdited: new Date(),
-            Status: Status.Draft
-        };
-    
-        // Update the documents state
-        setDocuments([...documents, newDocument]);
-        setNewTitle("");
-        setNewURL("");
-        setNewCategory("");
-        closeDialog();
-        alert("Created Successfully");
-    };
-
-    const changeDocumentStatus = (id: number) => {
-        setDocuments(prevDocuments => 
-            prevDocuments.map(doc => {
-                if (doc.Id === id) {
-                    let newStatus;
-                    switch (doc.Status) {
-                        case Status.Draft:
-                            newStatus = Status.Approved;
-                            break;
-                        case Status.Approved:
-                            newStatus = Status.Signed;
-                            break;
-                        case Status.Signed:
-                        case Status.Released:
-                            newStatus = Status.Released; 
-                            break;
-                        default:
-                            newStatus = doc.Status;
-                    }
-                    return {
-                        ...doc,
-                        Status: newStatus 
-                    };
-                }
-                return doc; 
-            })
-        );
-    }
-
-    const deleteDocument = (id: number) => {
-        setDocuments((prevDocuments) => prevDocuments.filter((doc) => doc.Id !== id));
-    }
-
-    const deleteShareRecipient = (userId: number, authorize: string) => {
-        setDocuments(prevDocuments => 
-            prevDocuments.map(doc => {
-                if (doc.Id === documentId) {
-                    return {
-                        ...doc,
-                        SharedWith: doc.SharedWith.filter(shar => !(shar.UserId === userId && shar.Authorize === authorize))
-                    };
-                }
-                return doc;
-            })
-        );
-    }
-
-    return (
-        <Card sx={{ p: 3, m: 2 }}>
-            <Box display="flex" justifyContent="space-between" alignItems="center">
-                <Box>
-                    <h1 style={{ fontWeight: "bold" }}>Document Management</h1>
-                    <p style={{ color: "gray" }}>Manage and track documents for ship sale closing</p>
-                </Box>
-                <Box display="flex" gap={1}>
-                    <Button 
-                    variant="contained" 
-                    onClick={openAddDocumentDialog} 
-                    sx={{ 
-                        mb: 2, 
-                        width: 200, 
-                        backgroundColor:"black", 
-                        '&:hover': { backgroundColor: 'darkgray' }}}>
-                        Add Document
-                    </Button>
-                </Box>
-            </Box>
-            <TableContainer component={Paper} sx={{ mt: 2 }}>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>#</TableCell>
-                            <TableCell>Document Name</TableCell>
-                            <TableCell>Category</TableCell>
-                            <TableCell>Shared With</TableCell>
-                            <TableCell>Creation Date</TableCell>
-                            <TableCell>Last Edited</TableCell>
-                            <TableCell>Status</TableCell>
-                            <TableCell>Actions</TableCell>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>
-                            <TableCell></TableCell>                            
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {
-                            documents.map((document, index) => (
-                                <TableRow key={index}>
-                                    <TableCell>{document.Id}</TableCell>
-                                    <TableCell>{document.DocumentName}</TableCell>
-                                    <TableCell>{document.Category}</TableCell>
-                                    <TableCell>
-                                        {document.SharedWith.map((user, index) =>(
-                                            <Avatar
-                                                key={index}
-                                                sx={{backgroundColor:getUser(user.UserId)?.backgroundColor, width:32, height: 32, fontSize: "1rem"}}>
-                                                {getUser(user.UserId)?.shortName}
-                                            </Avatar>
-                                        ))
-                                        }
-                                    </TableCell>
-                                    <TableCell>{document.CreationDate.toLocaleString()}</TableCell>
-                                    <TableCell>{document.LastEdited.toLocaleString()}</TableCell>
-                                    <TableCell>
-                                        <Button
-                                            variant="contained"
-                                            sx={{backgroundColor: getStatusColors(document.Status).backgroundColor,
-                                                color: getStatusColors(document.Status).textColor,
-                                                minWidth: 125,
-                                                borderRadius: 4,
-                                                mr: 2,
-                                                paddingBlock:0.5,
-                                                paddingLeft:1,
-                                                paddingRight:1,
-                                                fontSize:"14px",
-                                                fontWeight:"bold",
-                                                "&:hover":{backgroundColor:"#444444"}}}
-                                        >
-                                            {document.Status}
-                                        </Button>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Tooltip title="Preview" arrow>
-                                            <Button
-                                                variant="text"
-                                                color="inherit"
-                                                sx={{}}
-                                                onClick={() => openDraftDocumentDialog(document.Id)} >
-                                                <VisibilityIcon />
-                                            </Button>
-                                        </Tooltip>
-                                    </TableCell>
-                                    <TableCell>
-                                    <Tooltip 
-                                            title={
-                                                document.Status === Status.Draft ? "Approve" :
-                                                document.Status === Status.Approved ? "Sign" :
-                                                (document.Status === Status.Signed || document.Status === Status.Released) ? "Release" :
-                                                ""
-                                            }
-                                        >
-                                            <Button
-                                                variant="text"
-                                                color="inherit"
-                                                onClick={() => changeDocumentStatus(document.Id)}
-                                                disabled={document.Status === Status.Released ? true: false}
-                                            >
-                                                {document.Status === Status.Draft && <TaskAltIcon />}
-                                                {document.Status === Status.Approved && <CreateIcon />}
-                                                {(document.Status === Status.Signed || document.Status === Status.Released) && <OpenInNewIcon />}
-                                            </Button>
-                                        </Tooltip>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Tooltip title="Share Document">
-                                            <Button
-                                                variant="text"
-                                                color="inherit"
-                                                sx={{}}
-                                                onClick={() => openSharedDocumentDialog(document.Id)}>
-                                                <ShareIcon />
-                                            </Button>
-                                        </Tooltip>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Button
-                                            variant="text"
-                                            color="inherit"
-                                            sx={{}}
-                                            onClick={() => deleteDocument(document.Id)}>
-                                            <DeleteIcon />
-                                        </Button>
-                                    </TableCell>
-                                </TableRow>
-                            ))
-                        }
-                    </TableBody>
-                </Table>
-            </TableContainer>
-            <Dialog open={isAddDialogOpen} onClose={closeDialog} fullWidth>
-                <DialogTitle sx={{fontWeight: 'Bold'}}>Add New Document</DialogTitle>
-                <DialogContent>
-                    <TableContainer>
-                        <Table>
-                            <TableBody>
-                                <TableRow>
-                                    <TableCell><Typography variant="body1" fontWeight="bold" sx={{display:"flex", justifyContent:"flex-end"}}>Title</Typography>
-                                    </TableCell>
-                                    <TableCell>
-                                        <TextField
-                                            autoFocus
-                                            margin="dense"
-                                            type="text"
-                                            fullWidth
-                                            variant="outlined"
-                                            value={newTitle}
-                                            onChange={(e) => setNewTitle(e.target.value)}
-                                            error={documentError.title}
-                                            helperText={documentErrorMessage.title}
-                                        />
-                                    </TableCell>
-                                </TableRow>
-                                <TableRow>
-                                    <TableCell><Typography variant="body1" fontWeight="bold" sx={{display:"flex", justifyContent:"flex-end"}}>URL</Typography>
-                                    </TableCell>
-                                    <TableCell>
-                                        <TextField
-                                            autoFocus
-                                            margin="dense"
-                                            type="url"
-                                            fullWidth
-                                            variant="outlined"
-                                            value={newURL}
-                                            onChange={(e) => setNewURL(e.target.value)}
-                                            error={documentError.url}
-                                            helperText={documentErrorMessage.url}
-                                        />
-                                    </TableCell>
-                                </TableRow>
-                                    <TableCell><Typography variant="body1" fontWeight="bold" sx={{display:"flex", justifyContent:"flex-end"}}>Category</Typography>
-                                    </TableCell>
-                                    <TableCell>
-                                        <Box>
-                                            {documentErrorMessage.category && <Typography color="error">{documentErrorMessage.category}</Typography>}
-                                            <Select
-                                                value={newCategory || ""}
-                                                displayEmpty
-                                                onChange={(e) => setNewCategory(e.target.value)}
-                                                sx={{ height: 30, width: 160, minWidth: 160, borderColor: "lightGrey" }}
-                                                fullWidth
-                                                error = {documentError.category}
-                                            >
-                                                <MenuItem value="" disabled></MenuItem>
-                                                <MenuItem value="Legal">Legal</MenuItem>
-                                                <MenuItem value="Technical">Technical</MenuItem>
-                                                <MenuItem value="HR">HR</MenuItem>
-                                                <MenuItem value="Insurance">Insurance</MenuItem>
-                                                <MenuItem value="Compliance">Compliance</MenuItem>
-                                            </Select>
-                                        </Box>
-                                    </TableCell>
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
-                    <Box>
-                        
-                    </Box>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={closeDialog} variant="outlined">Cancel</Button>
-                    <Button onClick={addNewDocument} color="primary" variant="contained" sx={{ backgroundColor: 'black', color: 'white', '&:hover': { backgroundColor: 'darkgray' } }}>Add Document</Button>
-                </DialogActions>
-            </Dialog>
-            <Dialog open={isDraftDialogOpen} onClose={closeDialog} fullWidth>
-                <DialogTitle>
-                    <Box display="flex" justifyContent="space-between" alignItems="center">
-                        <Typography variant="h6" sx={{fontWeight: 'Bold'}}>{draftDialogTitle}</Typography>
-                        <Button onClick={closeDialog} color="inherit">
-                            <CloseIcon />
-                        </Button>
-                    </Box>
-                </DialogTitle>
-                <DialogContent>
-                <DialogContent dividers style={{ textAlign: 'center', height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: '#f5f5f5' }}>
-                    <Typography variant="h6" style={{ fontWeight: 'normal' }}>
-                        Preview of {draftDialogTitle}
-                    </Typography>
-                    <Box position="absolute" style={{ opacity: 0.1, fontSize: '4rem', color: 'gray' }}>
-                        DRAFT
-                    </Box>
-                    </DialogContent>
-                </DialogContent>
-            </Dialog>
-            <Dialog open={isSharedDialogOpen} onClose={closeDialog} fullWidth>
-                <DialogTitle>
-                    <Box display="flex" justifyContent="space-between" alignItems="center">
-                        <Typography variant="h6" sx={{fontWeight: 'Bold'}}>Share Document: {shareDialogTitle}</Typography>
-                        <Button onClick={closeDialog} color="inherit">
-                            <CloseIcon />
-                        </Button>
-                    </Box>
-                </DialogTitle>
-                <DialogContent>
-                    <TableContainer>
-                        <Table>
-                            <TableBody>
-                                <TableRow>
-                                    <TableCell><Typography variant="body1" fontWeight="bold" sx={{display:"flex", justifyContent:"flex-end"}}>Recipient:</Typography></TableCell>
-                                    <TableCell>
-                                        <Box>
-                                            {shareDocumentErrorMessage.recipient && <Typography color="error">{shareDocumentErrorMessage.recipient}</Typography>}
-                                            <Select
-                                            sx={{alignItems:"flex-start", width: 250}}
-                                            fullWidth
-                                            value={userId}
-                                            onChange={(e) => setUserId(Number(e.target.value))} 
-                                            error={shareDocumentError.recipient}
-                                            >
-                                                <MenuItem value="0"></MenuItem>
-                                                {users.map((user) => (
-                                                    <MenuItem key={user.id} value={user.id}>{user.name}</MenuItem>
-                                                ))}
-                                            </Select>
-                                        </Box>
-                                    </TableCell>
-                                </TableRow>
-                                <TableRow>
-                                    <TableCell><Typography variant="body1" fontWeight="bold" sx={{display:"flex", justifyContent:"flex-end"}}>Action:</Typography></TableCell>
-                                    <TableCell>
-                                        <Box>
-                                            {shareDocumentErrorMessage.action && <Typography color="error">{shareDocumentErrorMessage.action}</Typography>}
-                                            <Select
-                                                value={authorize}
-                                                sx={{alignItems:"flex-start", width: 250}}
-                                                defaultValue={"Needs to Sign"}
-                                                onChange={(e) => setAuthorize(e.target.value)}
-                                                error={shareDocumentError.action}>
-                                                    <MenuItem key="Sign" value="Needs to Sign">Needs to Sign</MenuItem>
-                                                    <MenuItem key="View" value="Needs to View">Needs to View</MenuItem>
-                                            </Select>
-                                        </Box>
-                                    </TableCell>
-                                </TableRow>
-                            </TableBody>
-                        </Table>
-                    </TableContainer>
-                    <Button onClick={addShareRecipient} sx={{bgcolor:"#000000", color: "#FFFFFF", '&:hover': { backgroundColor: 'darkgray' }}} fullWidth>
-                        Add Recipient
-                    </Button>
-                    <Box>
-                        <Typography variant="body1" fontWeight="bold">Current Recipients:</Typography>
-                        {getDocument(documentId)?.SharedWith.map((role, index) => (
-                           <Box key={index} sx={{ display: "flex", justifyContent: "space-between", alignItems: "flex-end", width: '100%' }}>
-                                <Typography variant="body1">
-                                    <b>{getUser (role.UserId)?.name}:</b> {role.Authorize}
-                                </Typography>
-                                <Button onClick={() => deleteShareRecipient(role.UserId, role.Authorize)}>
-                                    <PersonRemoveIcon />
-                                </Button>
-                            </Box>
-                        ))}
-                    </Box>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={closeDialog} color="inherit" variant="contained" sx={{fontSize:12, minWidth:100,}}>Cancel</Button>
-                    <Button onClick={closeDialog} color="inherit" variant="contained" sx={{fontSize:12, minWidth:100, bgcolor:"#000000", color:"#FFFFFF"}}>Share</Button>
-                </DialogActions>
-            </Dialog>
-        </Card>
-       
+        return doc;
+      })
     );
-}
+  };
+
+  const addShareRecipient = () => {
+    if (!userId || !authorize) return;
+
+    setDocuments(
+      documents.map((doc) => {
+        if (doc.Id === documentId) {
+          return {
+            ...doc,
+            SharedWith: [
+              ...doc.SharedWith,
+              { UserId: userId, Authorize: authorize },
+            ],
+          };
+        }
+        return doc;
+      })
+    );
+    setUserId(0);
+    setAuthorize("");
+  };
+
+  const deleteShareRecipient = (userId: number, authorize: string) => {
+    setDocuments(
+      documents.map((doc) => {
+        if (doc.Id === documentId) {
+          return {
+            ...doc,
+            SharedWith: doc.SharedWith.filter(
+              (share) =>
+                share.UserId !== userId || share.Authorize !== authorize
+            ),
+          };
+        }
+        return doc;
+      })
+    );
+  };
+
+  const getStatusColors = (status: Status) => {
+    switch (status) {
+        case Status.Draft:
+            return { backgroundColor: "#fef08a", textColor: "#854D0E" };
+        case Status.Approved:
+            return { backgroundColor: "#bfdbfe", textColor: "#1e40af" };
+        case Status.Released:
+            return { backgroundColor: "#e9d5ff", textColor: "#6b21a8" };
+        case Status.Signed:
+            return { backgroundColor: "#bbf7d0", textColor: "#166534" };
+        default:
+            return { backgroundColor: "#ffffff", textColor: "#000000" }; // Default colors
+    }
+};
+
+  const commandBarItems = (doc: Document) => {
+    return [
+      {
+        key: "preview",
+        text: <Eye24Filled />,
+        iconProps: { iconName: "RedEye" },
+        onClick: () => openDraftDocumentDialog(doc.Id),
+      },
+      {
+        key: "changeStatus",
+        text: doc.Status === Status.Draft ? <CheckmarkCircle24Regular /> : 
+            doc.Status === Status.Approved ? <Pen24Filled /> : 
+            (doc.Status === Status.Signed || doc.Status === Status.Released) ? <Open24Filled /> : ""
+        ,
+        iconProps: { iconName: "Sync" },
+        disabled: doc.Status === "Released",
+        onClick: () => changeDocumentStatus(doc.Id),
+      },
+      {
+        key: "share",
+        text: <Share24Regular />,
+        iconProps: { iconName: "Share" },
+        onClick: () => openSharedDocumentDialog(doc.Id),
+      },
+      {
+        key: "delete",
+        text: <Delete24Filled />,
+        iconProps: { iconName: "Delete" },
+        onClick: () => deleteDocument(doc.Id),
+      },
+    ];
+  };
+
+  const columns: IColumn[] = [
+    { key: "column1", 
+      name: "#", 
+      fieldName: "Id",
+      isResizable:true, 
+      minWidth: 30, 
+      maxWidth: 50,
+      onRender: (item: Document, index?: number) => (
+        <span style={{ fontSize: 14 }}>{(index ?? 0) + 1}</span>
+      ),
+    },
+    {
+      key: "column2",
+      name: "Document Name",
+      fieldName: "DocumentName",
+      isResizable:true, 
+      minWidth: 100,
+      onRender: (item: Document) => (
+        <span style={{ fontSize: 14 }}>{item.DocumentName}</span>
+      ),
+    },
+    {
+      key: "column3",
+      name: "Category",
+      fieldName: "Category",
+      isResizable:true, 
+      minWidth: 100,
+      onRender: (item: Document) => (
+        <span style={{ fontSize: 14 }}>{item.Category}</span>
+      ),
+    },
+    {
+      key: "column4",
+      name: "Shared With",
+      isResizable:true, 
+      onRender: (item: Document) => (
+        <Stack horizontal tokens={{ childrenGap: 5 }}>
+          {item.SharedWith.map((share, index) => (
+            <Persona
+              key={index}
+              text={getUser(share.UserId).name}
+              hidePersonaDetails
+            />
+          ))}
+        </Stack>
+      ),
+      minWidth: 150,
+    },
+    {
+      key: "column5",
+      name: "Creation Date",
+      isResizable:true, 
+      minWidth: 120,
+      onRender: (item: Document) => (
+        <span style={{ fontSize: 14 }}>
+          {item.CreationDate.toLocaleDateString()}
+        </span>
+      ),
+    },
+    {
+      key: "column6",
+      name: "Last Edited",
+      isResizable:true, 
+      minWidth: 120,
+      onRender: (item: Document) => (
+        <span style={{ fontSize: 14 }}>
+          {item.LastEdited.toLocaleDateString()}
+        </span>
+      ),
+    },
+    {
+      key: "column7",
+      name: "Status",
+      isResizable:true, 
+      minWidth: 80,
+      onRender: (item: Document) => (
+        <span
+          style={{
+            display: "flex",
+            alignItems: "center",  // Căn giữa theo chiều dọc
+            textAlign:"center",
+            height: "100%", 
+            backgroundColor:getStatusColors(item.Status).backgroundColor,
+            color: getStatusColors(item.Status).textColor,
+            fontWeight: "bold",
+            fontSize: 14,
+            padding:"10px 10px",
+            borderRadius:10,
+            width:"fit-content",
+            transition: "all 0.2s ease",
+          }}
+        >
+          {item.Status}
+        </span>
+      ),
+    },
+    {
+      key: "column8",
+      name: "Actions",
+      isResizable:true, 
+      onRender: (item: Document) => (
+        <CommandBar
+          items={commandBarItems(item)}
+          styles={{ root: { padding: 0 } }}
+        />
+      ),
+      minWidth: 210,
+      maxWidth: 225,
+    },
+  ];
+
+  return (
+    // <Stack style={{ padding: 16, margin: 16 }}>
+    <Stack className={useStyles.container}>
+      <Stack horizontal horizontalAlign="space-between" className={useStyles.header}>
+        <Stack>
+          <Text variant="xLargePlus" styles={{ root: { fontWeight: 'bold', marginTop: 10} }}>
+            Document Management
+          </Text>
+          <Text variant="medium" style={{ color: "gray", marginTop: 20}}>
+            Manage and track documents for ship sale closing
+          </Text>
+        </Stack>
+        <PrimaryButton 
+          text="Add Document" 
+          onClick={openAddDocumentDialog} 
+          styles={{ 
+            root: { 
+              width: 250, 
+              backgroundColor: 'black', 
+              color: 'white'
+            }, 
+            rootHovered: { 
+              backgroundColor: 'darkgray' 
+            },
+            label: {
+              fontWeight:"bold", 
+              fontSize:17
+            } }} />
+      </Stack>
+
+      <DetailsList
+        items={documents}
+        columns={columns}
+        layoutMode={DetailsListLayoutMode.justified}
+        selectionMode={SelectionMode.none}
+        className={useStyles.tableBody}
+        styles={{
+            root: {
+                width: '100%'
+            },
+            contentWrapper: {
+                display: 'flex',
+                flexGrow: 1
+            }
+        }}
+      />
+
+      {/* Add Document Dialog */}
+      <Dialog open={isAddDialogOpen} onOpenChange={closeDialog}>
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle style={{fontWeight: 'Bold'}}>Add New Document</DialogTitle>
+            <DialogContent>
+              <Label>Document Name</Label>
+              <TextField
+                type="text"
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                style={{ marginBottom: 8,width:"100%"}}
+                errorMessage = {documentErrorMessage.title ? documentErrorMessage.title : ""}
+              />
+
+              <Label>Document URL</Label>
+              <TextField
+                type="text"
+                value={newURL}
+                onChange={(e) => setNewURL(e.target.value)}
+                style={{ marginBottom: 8,width:"100%" }}
+                errorMessage = {documentErrorMessage.url ? documentErrorMessage.url : ""}
+              />
+
+              <Label>Category</Label>
+              {documentErrorMessage.category && (
+                <Text style={{ color: "red" }}>{documentErrorMessage.category}</Text>
+              )}
+              <Dropdown
+                value={newCategory || ""}
+                placeholder="Select Category"
+                selectedOptions={newCategory ? [newCategory] : []}
+                onOptionSelect={(e, data) => {
+                    setNewCategory(data.optionValue); // Lấy giá trị từ option được chọn
+                }}
+                style={{ marginBottom: 8, width: "100%" }}
+                >
+                <Option value="Legal">Legal</Option>
+                <Option value="Technical">Technical</Option>
+                <Option value="HR">HR</Option>
+                <Option value="Insurance">Insurance</Option>
+                <Option value="Compliance">Compliance</Option>
+              </Dropdown>
+             
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={closeDialog}>Cancel</Button>
+              <Button appearance="primary" onClick={addNewDocument}>
+                Add Document
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+
+      {/* Shared Document Dialog */}
+      <Dialog open={isSharedDialogOpen} onOpenChange={closeDialog}>
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Share Document: {shareDialogTitle}</DialogTitle>
+            <DialogContent>
+              <Label>Document Name</Label>
+              <Dropdown
+                placeholder="Select Recipient"
+                selectedOptions={userId ? [userId.toString()] : []}
+                onOptionSelect={(e, data) => setUserId(Number(data.optionValue))}
+                style={{width:"100%"}}
+              >
+                {users.map((user) => (
+                  <Option key={user.id} value={user.id.toString()}>
+                    {user.name}
+                  </Option>
+                ))}
+              </Dropdown>
+
+              <Label>Document Name</Label>
+              <Dropdown
+                placeholder="Select Action"
+                selectedOptions={authorize ? [authorize] : []}
+                onOptionSelect={(e, data) => setAuthorize(data.optionValue)}
+                style={{width:"100%"}}
+              >
+                <Option value="Needs to Sign">Needs to Sign</Option>
+                <Option value="Needs to View">Needs to View</Option>
+              </Dropdown>
+
+              <Button onClick={addShareRecipient} appearance="primary" 
+                    style={{width:"100%", marginTop:15, marginBottom:15}}>
+                Add Recipient
+              </Button>
+
+              {documents
+                .find((d) => d.Id === documentId)
+                ?.SharedWith.map((share, index) => (
+                  <Stack horizontal key={index} horizontalAlign="space-between"
+                    style={{width:"100%", marginTop:15, marginBottom:15}}>
+                    <Text>
+                      {getUser(share.UserId)?.name}: {share.Authorize}
+                    </Text>
+                    <Button
+                      icon={<PersonDelete24Filled />}
+                      onClick={() =>
+                        deleteShareRecipient(share.UserId, share.Authorize)
+                      }
+                    />
+                  </Stack>
+                ))}
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={closeDialog}>Close</Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+
+      {/* Draft Document Dialog */}
+      <Dialog open={isDraftDialogOpen} onOpenChange={closeDialog}>
+        <DialogSurface>
+        <DialogBody> {/* Container phải có relative để định vị tuyệt đối bên trong */}
+  
+        {/* Nút Close ở góc phải */}
+        <Button
+            icon={<Dismiss24Regular />}
+            onClick={closeDialog}
+            style={{
+            position: 'absolute',
+            top: 16,     // khoảng cách từ trên xuống
+            right: 16,   // khoảng cách từ phải vào
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer'
+            }}
+        />
+
+        {/* Nội dung Dialog */}
+        <DialogTitle>{draftDialogTitle}</DialogTitle>
+
+        <DialogContent>
+        <DialogContent style={{ textAlign: 'center', height: '200px', display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: '#f5f5f5' }}>
+            <Text variant="large" style={{ fontWeight: 'normal' }}>
+                Preview of {draftDialogTitle}
+            </Text>
+            <Label style={{ opacity: 0.1, fontSize: '4rem', color: 'gray' }}>
+                DRAFT
+            </Label>
+            </DialogContent>
+        </DialogContent>
+
+        </DialogBody>
+
+        </DialogSurface>
+      </Dialog>
+    </Stack>
+  );
+};
 
 export default Documents;

--- a/src/components/Participants.tsx
+++ b/src/components/Participants.tsx
@@ -1,24 +1,24 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import {
-    Card,Box,
-    Table,
-    TableHead,
-    TableBody,
-    TableRow,
-    TableCell,
-    TableContainer,
-    Paper,
-    Button,
-    Select,
-    MenuItem,
-    Dialog, 
-    DialogTitle, 
-    DialogContent, 
-    DialogActions, 
+    Stack,
+    DefaultButton,
+    PrimaryButton,
+    IconButton,
     TextField,
-    Typography
-} from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
+    Dropdown,
+    IDropdownOption,
+    Dialog,
+    DialogType,
+    DialogFooter,
+    DetailsList,
+    DetailsListLayoutMode,
+    SelectionMode,
+    IColumn,
+    Label,
+    Text,
+    mergeStyleSets
+} from "@fluentui/react";
+import { Delete24Filled } from "@fluentui/react-icons";
 
 export interface User {
     id: number;
@@ -36,17 +36,17 @@ export enum Permission {
 }
 
 export const initialUsers: User[] = [
-    {id: 1, name: "John Doe", shortName:"JD", role:"", permission: [Permission.APPROVE, Permission.SIGN, Permission.RELEASE], backgroundColor: "#b7103d"},
-    {id: 2, name: "Jane Smith", shortName:"JM", role:"", permission: [Permission.APPROVE, Permission.SIGN], backgroundColor:"#6cd145" },
-    {id: 3, name: "Mike Johnson", shortName:"MJ", role:"", permission: [Permission.APPROVE, Permission.SIGN],backgroundColor:"#5a5b5b" },
-    {id: 4, name: "Sarah Lee", shortName:"SL", role:"", permission: [Permission.APPROVE], backgroundColor:"#39544f" },
-    {id: 5, name: "Tom Brown", shortName:"TB", role:"", permission: [], backgroundColor:"#330428" },
-    {id: 6, name: "Emily Davis", shortName:"ED", role:"", permission: [Permission.APPROVE], backgroundColor: "#0800f7" },
-    {id: 7, name: "Chris Wilson", shortName:"CW", role:"", permission: [], backgroundColor:"#9eb5c1" },
-    {id: 8, name: "Alex Johnson", shortName:"AJ", role:"", permission: [], backgroundColor:"#897a6a" },
+    { id: 1, name: "John Doe", shortName: "JD", role: "", permission: [Permission.APPROVE, Permission.SIGN, Permission.RELEASE], backgroundColor: "#b7103d" },
+    { id: 2, name: "Jane Smith", shortName: "JM", role: "", permission: [Permission.APPROVE, Permission.SIGN], backgroundColor: "#6cd145" },
+    { id: 3, name: "Mike Johnson", shortName: "MJ", role: "", permission: [Permission.APPROVE, Permission.SIGN], backgroundColor: "#5a5b5b" },
+    { id: 4, name: "Sarah Lee", shortName: "SL", role: "", permission: [Permission.APPROVE], backgroundColor: "#39544f" },
+    { id: 5, name: "Tom Brown", shortName: "TB", role: "", permission: [], backgroundColor: "#330428" },
+    { id: 6, name: "Emily Davis", shortName: "ED", role: "", permission: [Permission.APPROVE], backgroundColor: "#0800f7" },
+    { id: 7, name: "Chris Wilson", shortName: "CW", role: "", permission: [], backgroundColor: "#9eb5c1" },
+    { id: 8, name: "Alex Johnson", shortName: "AJ", role: "", permission: [], backgroundColor: "#897a6a" },
 ];
 
-const roles = [
+const roles: string[] = [
     "Buyer",
     "Seller",
     "Bank for Buyer",
@@ -59,42 +59,60 @@ const roles = [
     "Ship Registry"
 ];
 
+const roleOptions: IDropdownOption[] = roles.map(role => ({ key: role, text: role }));
+
+const useStyles = mergeStyleSets({
+    container: {
+        padding: 20,
+        margin: 20,
+        border: '1px solid #e1e1e1',
+        borderRadius: 8
+    },
+    header: {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        marginBottom: 20
+    },
+    permissionButton: {
+        marginRight: 8
+    },
+    tableBody: {
+    },
+    tableCell: {
+        alignItems: 'center'
+    }
+});
+
 const Participants = () => {
-    const [participants, setParticipants] = useState(initialUsers);
+    const [participants, setParticipants] = useState<User[]>(initialUsers);
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [newName, setNewName] = useState("");
-    const [selectedRole, setSelectedRole] = useState("");
+    const [selectedRole, setSelectedRole] = useState<string>("");
     const [selectedPermissions, setSelectedPermissions] = useState<Permission[]>([]);
-    const [error, setError] = useState({
-        name: false,
-    });
-    const [errorMessage, setErrorMessage] = useState({
-        name:""
-    })
+    const [error, setError] = useState({ name: false });
+    const [errorMessage, setErrorMessage] = useState({ name: "" });
 
     const addParticipant = () => {
-        setError({name:false});
-        setErrorMessage({name:""});
-        let hasError = false;
-        if(!newName.trim()){
-            setErrorMessage(prev => ({ ...prev, name: "This field is required" }));
-            setError(prev => ({ ...prev, name: true }));
-            hasError = true;
+        setError({ name: false });
+        setErrorMessage({ name: "" });
+
+        if (!newName.trim()) {
+            setErrorMessage({ name: "This field is required" });
+            setError({ name: true });
+            return;
         }
-        if(hasError) return;
 
         const getRandomHexColor = () => {
-            const randomChannel = () => Math.floor(Math.random() * 256)
-                .toString(16)
-                .padStart(2, '0'); // Đảm bảo luôn có 2 ký tự
+            const randomChannel = () => Math.floor(Math.random() * 256).toString(16).padStart(2, '0');
             return `#${randomChannel()}${randomChannel()}${randomChannel()}`;
         };
 
-        const newParticipant: User ={
+        const newParticipant: User = {
             id: participants.length + 1,
             name: newName,
             role: selectedRole,
-            shortName: newName.split(' ').filter(word => word).map(word => word[0].toUpperCase()).join(''),
+            shortName: newName.split(' ').map(word => word[0]?.toUpperCase() || '').join(''),
             permission: selectedPermissions,
             backgroundColor: getRandomHexColor()
         };
@@ -103,19 +121,19 @@ const Participants = () => {
         closeDialog();
         resetData();
         alert("Created Successfully");
-    }
+    };
 
     const updateParticipant = (updatedParticipant: User) => {
-        setParticipants(prev => 
-            prev.map(participant => 
+        setParticipants(prev =>
+            prev.map(participant =>
                 participant.id === updatedParticipant.id ? updatedParticipant : participant
             )
         );
     };
-    
-    const deleteParticipant = (id: any) => {
-        setParticipants((prevParticipants) => prevParticipants.filter((participant) => participant.id !== id));
-    }
+
+    const deleteParticipant = (id: number) => {
+        setParticipants(prev => prev.filter(participant => participant.id !== id));
+    };
 
     const getPermissionColors = (permission: Permission) => {
         switch (permission) {
@@ -126,27 +144,24 @@ const Participants = () => {
             case Permission.SIGN:
                 return { backgroundColor: "#bbf7d0", textColor: "#166534" };
             default:
-                return { backgroundColor: "#ffffff", textColor: "#000000" }; // Default colors
+                return { backgroundColor: "#ffffff", textColor: "#000000" };
         }
     };
 
-    const handleRoleChange = (id:any, role:any) => {
-        setParticipants((prevParticipants) => 
-            prevParticipants.map((participant) => 
+    const handleRoleChange = (id: number, role: string) => {
+        setParticipants(prev =>
+            prev.map(participant =>
                 participant.id === id ? { ...participant, role } : participant
             )
         );
-    }
+    };
 
     const toggleCreatePermission = (permission: Permission) => {
-        setSelectedPermissions((prev) => {
-            if (prev.includes(permission)) {
-                return prev.filter((p) => p !== permission); // Remove permission if already selected
-            } else {
-                return [...prev, permission]; // Add permission if not selected
-            }
-        });
-    }
+        setSelectedPermissions(prev => prev.includes(permission)
+            ? prev.filter(p => p !== permission)
+            : [...prev, permission]);
+    };
+
     const togglePermission = (participant: User, permission: Permission) => {
         const updatedPermissions = participant.permission.includes(permission)
             ? participant.permission.filter(p => p !== permission)
@@ -155,246 +170,193 @@ const Participants = () => {
         updateParticipant({ ...participant, permission: updatedPermissions });
     };
 
-    const openDialog = () => {
-        setIsDialogOpen(true);
-    }
-
-    const closeDialog = () => {
-        setIsDialogOpen(false);
-    }
+    const openDialog = () => setIsDialogOpen(true);
+    const closeDialog = () => setIsDialogOpen(false);
 
     const resetData = () => {
         setNewName("");
         setSelectedRole("");
         setSelectedPermissions([]);
-    }
+    };
+
+    const columns: IColumn[] = [
+        {
+            key: 'column1',
+            name: 'Name',
+            fieldName: 'name',
+            minWidth: 180,
+            maxWidth:400,
+            isResizable: true,
+            isMultiline: true,
+            onRender: (participant: User) => (
+                <Text>{participant.name}</Text>
+            )
+        },
+        {
+            key: 'column2',
+            name: 'Role',
+            minWidth: 200,
+            maxWidth: 400,
+            isResizable:true,
+            onRender: (participant: User) => (
+                <Dropdown
+                    placeholder="Select a role"
+                    selectedKey={participant.role}
+                    options={roleOptions}
+                    onChange={(e, option) => handleRoleChange(participant.id, option?.text || '')}
+                    styles={{ dropdown: { width: 180 } }}
+                />
+            )
+        },
+        {
+            key: 'column3',
+            name: 'Permissions',
+            minWidth: 300,
+            maxWidth: 500,
+            isResizable: true,
+            onRender: (participant: User) => (
+                <Stack horizontal>
+                    {[Permission.APPROVE, Permission.SIGN, Permission.RELEASE].map(perm => {
+                        const selected = participant.permission.includes(perm);
+                        const { backgroundColor, textColor } = getPermissionColors(perm);
+                        return (
+                            <DefaultButton
+                                key={perm}
+                                text={perm}
+                                onClick={() => togglePermission(participant, perm)}
+                                styles={{
+                                    root: {
+                                        backgroundColor: selected ? backgroundColor : '#CCCCCC',
+                                        color: selected ? textColor : '#888888',
+                                        marginRight: 8,
+                                        borderRadius: 4,
+                                        height: 32
+                                    }
+                                }}
+                            />
+                        );
+                    })}
+                </Stack>
+            )
+        },
+        {
+            key: 'column4',
+            name: 'Actions',
+            minWidth: 50,
+            isResizable:true,
+            onRender: (participant: User) => (
+                <IconButton
+                    onClick={() => deleteParticipant(participant.id)}
+                    styles={{
+                        root: {
+                            padding: 4,
+                        }
+                    }}
+                >
+                    <Delete24Filled primaryFill="#000000" />
+                </IconButton>
+            )
+        }
+    ];
 
     return (
-        <Card sx={{ p: 3, m: 2 }}>
-            <Box display="flex" justifyContent="space-between" alignItems="center">
-                <Box>
-                    <h1 style={{ fontWeight: "bold" }}>Role & Participant Management</h1>
-                </Box>
-                <Button 
-                variant="contained" 
-                onClick={openDialog} 
-                sx={{ 
-                    mb: 2, 
-                    width: 200, 
-                    backgroundColor:"black", 
-                    '&:hover': {backgroundColor: 'darkgray' }}}>
-                    Add Participant
-                </Button>
+        <Stack className={useStyles.container}>
+            <Stack horizontal horizontalAlign="space-between" className={useStyles.header}>
+                <Text variant="xLargePlus" styles={{ root: { fontWeight: 'bold'} }}>Role & Participant Management</Text>
+                <PrimaryButton 
+                    text="Add Participant" 
+                    onClick={openDialog} 
+                    styles={{ 
+                        root: { 
+                            width: 250, 
+                            backgroundColor: 'black', 
+                            color: 'white', 
+                            fontSize:18}, 
+                        rootHovered: { 
+                            backgroundColor: 'darkgray' 
+                        },
+                        label: { fontWeight: 'bold', fontSize: 17 } }} />
+            </Stack>
 
-            </Box>
+            <DetailsList
+                items={participants}
+                columns={columns}
+                layoutMode={DetailsListLayoutMode.justified}
+                selectionMode={SelectionMode.none}
+                className={useStyles.tableBody}
+                styles={{
+                    root: {
+                        width: '100%'
+                    },
+                    contentWrapper: {
+                        display: 'flex',
+                        flexGrow: 1
+                    }
+                }}
+            />
 
-            <TableContainer component={Paper} sx={{ mt: 2, width: "100%"}}>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell>Name</TableCell>
-                            <TableCell>Role</TableCell>
-                            <TableCell>Permissions</TableCell>
-                            <TableCell>Actions</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        {participants.map((participant) => (
-                            <TableRow key={participant.id}>
-                                <TableCell sx={{maxWidth:10}}>{participant.name}</TableCell>
-                                <TableCell>
-                                    <Select
-                                        value={participant.role || ""}
-                                        onChange={(e) => handleRoleChange(participant.id, e.target.value)}
-                                        displayEmpty
-                                        sx={{width: 200}}
-                                    >
-                                        <MenuItem value=""></MenuItem>
-                                        {roles.map((role) => (
-                                            <MenuItem key={role} value={role}>{role}</MenuItem>
-                                        ))}
-                                    </Select>
-                                </TableCell>
-                                
-                                {/* <TableCell>{participant.permission.join(", ")}</TableCell> */}
-                                <TableCell>
-                                    <Button
-                                        variant="contained"
-                                        onClick={() => togglePermission(participant, Permission.APPROVE)}
-                                        sx={{backgroundColor: participant.permission.includes(Permission.APPROVE) ? getPermissionColors(Permission.APPROVE).backgroundColor : "#CCCCCC",
-                                            color: participant.permission.includes(Permission.APPROVE)? getPermissionColors(Permission.APPROVE).textColor: "#888888",
-                                            minWidth: 80,
-                                            borderRadius: 4,
-                                            mr: 2,
-                                            paddingBlock:0.5,
-                                            paddingLeft:1,
-                                            paddingRight:1,
-                                            fontSize:"14px",
-                                            fontWeight:"bold"}}
-                                    >
-                                        APPROVE
-                                    </Button>
-                                    <Button
-                                        variant="contained"
-                                        onClick={() => togglePermission(participant, Permission.SIGN)}
-                                        sx={{backgroundColor: participant.permission.includes(Permission.SIGN) ? getPermissionColors(Permission.SIGN).backgroundColor : "#CCCCCC",
-                                            color: participant.permission.includes(Permission.SIGN)? getPermissionColors(Permission.SIGN).textColor: "#888888",
-                                            minWidth: 80,
-                                            borderRadius: 4,
-                                            mr: 2,
-                                            paddingBlock:0.5,
-                                            paddingLeft:1,
-                                            paddingRight:1,
-                                            fontSize:"14px",
-                                            fontWeight:"bold"}}
-                                    >
-                                        SIGN
-                                    </Button>
-                                    <Button
-                                        variant="contained"
-                                        onClick={() => togglePermission(participant, Permission.RELEASE)}
-                                        sx={{backgroundColor: participant.permission.includes(Permission.RELEASE) ? getPermissionColors(Permission.RELEASE).backgroundColor : "#CCCCCC",
-                                            color: participant.permission.includes(Permission.RELEASE)? getPermissionColors(Permission.RELEASE).textColor: "#888888",
-                                            minWidth: 80,
-                                            borderRadius: 4,
-                                            mr: 2,
-                                            paddingBlock:0.5,
-                                            paddingLeft:1,
-                                            paddingRight:1,
-                                            fontSize:"14px",
-                                            fontWeight:"bold"}}
-                                    >
-                                        RELEASE
-                                    </Button>
-                                </TableCell>
-
-                                <TableCell>
-                                    <Button
-                                        variant="text"
-                                        color="inherit"
-                                        onClick={() => deleteParticipant(participant.id)}>
-                                        <DeleteIcon />
-                                    </Button>   
-                                </TableCell>
-                            </TableRow>
-                        ))}
-                    </TableBody>
-                </Table>
-            </TableContainer>
-            <Dialog open={isDialogOpen} onClose={closeDialog} fullWidth>
-                <DialogTitle sx={{fontWeight: 'Bold'}}>Add New Participant</DialogTitle>
-                <DialogContent>
-                    <Box sx={{ mb: 2, display: 'flex', flexDirection: 'column' }}>
-                        {/* Name */}
-                        <Typography variant="body1" fontWeight="bold">Participant's name</Typography>
-                        <TextField
-                        autoFocus
-                        margin="dense"
-                        type="text"
-                        fullWidth
-                        variant="outlined"
+            <Dialog
+                hidden={!isDialogOpen}
+                onDismiss={closeDialog}
+                dialogContentProps={{
+                    type: DialogType.largeHeader,
+                    title: 'Add New Participant'
+                }}
+                modalProps={{
+                    isBlocking: false
+                }}
+                minWidth={600}
+                maxWidth={600}
+            >
+                <Stack tokens={{ childrenGap: 15 }}>
+                    <Label>Participant's name</Label>
+                    <TextField
                         value={newName}
-                        onChange={(e) => setNewName(e.target.value)}
-                        error={error.name}
-                        helperText={errorMessage.name}
+                        onChange={(e, newValue) => setNewName(newValue || "")}
+                        errorMessage={error.name ? errorMessage.name : ""}
                     />
-                    </Box>
 
-                    <Box sx={{mb:2}}>
-                        {/* Task Type Selection */}
-                        <Typography variant="body1" fontWeight="bold">Role</Typography>
-                        <Select
-                            value={selectedRole}
-                            onChange={(e) => setSelectedRole(e.target.value)}
-                            fullWidth
-                            variant="outlined"
-                        >
-                            {roles.map((role) => (
-                                <MenuItem value={role}>
-                                    {role}
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    </Box>
-                    
-                    <Box sx={{mb:2}}>
-                    {/* Task Type Selection */}
-                    <Typography variant="body1" fontWeight="bold">Permissions</Typography>
-                    <Button
-                            variant="contained"
-                            onClick={() => toggleCreatePermission(Permission.APPROVE)}
-                            sx={{
-                                backgroundColor: selectedPermissions.includes(Permission.APPROVE)
-                                    ? getPermissionColors(Permission.APPROVE).backgroundColor
-                                    : 'lightgray',
-                                color: selectedPermissions.includes(Permission.APPROVE)
-                                    ? getPermissionColors(Permission.APPROVE).textColor
-                                    : 'black',
-                                minWidth: 80,
-                                borderRadius: 4,
-                                mr: 1,
-                                paddingBlock:0.5,
-                                paddingLeft:1,
-                                paddingRight:1,
-                                fontSize:"14px",
-                                fontWeight: selectedPermissions.includes(Permission.APPROVE)? "bold" : "normal"
-                            }}
-                        >
-                            APPROVE
-                        </Button>
-                    <Button
-                            variant="contained"
-                            onClick={() => toggleCreatePermission(Permission.SIGN)}
-                            sx={{
-                                backgroundColor: selectedPermissions.includes(Permission.SIGN)
-                                    ? getPermissionColors(Permission.SIGN).backgroundColor
-                                    : 'lightgray',
-                                color: selectedPermissions.includes(Permission.SIGN)
-                                    ? getPermissionColors(Permission.SIGN).textColor
-                                    : 'black',
-                                minWidth: 80,
-                                borderRadius: 4,
-                                mr: 1,
-                                paddingBlock:0.5,
-                                paddingLeft:1,
-                                paddingRight:1,
-                                fontSize:"14px",
-                                fontWeight: selectedPermissions.includes(Permission.SIGN)? "bold" : "normal"
-                            }}
-                        >
-                            SIGN
-                        </Button>
-                    <Button
-                            variant="contained"
-                            onClick={() => toggleCreatePermission(Permission.RELEASE)}
-                            sx={{
-                                backgroundColor: selectedPermissions.includes(Permission.RELEASE)
-                                    ? getPermissionColors(Permission.RELEASE).backgroundColor
-                                    : 'lightgray',
-                                color: selectedPermissions.includes(Permission.RELEASE)
-                                    ? getPermissionColors(Permission.RELEASE).textColor
-                                    : 'black',
-                                minWidth: 80,
-                                borderRadius: 4,
-                                mr: 1,
-                                paddingBlock:0.5,
-                                paddingLeft:1,
-                                paddingRight:1,
-                                fontSize:"14px",
-                                fontWeight: selectedPermissions.includes(Permission.RELEASE)? "bold" : "normal"
-                            }}
-                        >
-                            RELEASE
-                        </Button>
-                </Box>
-                </DialogContent>
-                <DialogActions>
-                    <Button onClick={closeDialog} variant="outlined">Cancel</Button>
-                    <Button onClick={addParticipant} color="primary" variant="contained" sx={{backgroundColor: 'black', color: 'white', '&:hover': {backgroundColor:'darkgray'}}}>Add Participant</Button>
-                </DialogActions>
+                    <Label>Role</Label>
+                    <Dropdown
+                        placeholder="Select a role"
+                        selectedKey={selectedRole}
+                        options={roleOptions}
+                        onChange={(e, option) => setSelectedRole(option?.text || '')}
+                    />
+
+                    <Label>Permissions</Label>
+                    <Stack horizontal>
+                        {[Permission.APPROVE, Permission.SIGN, Permission.RELEASE].map(perm => {
+                            const selected = selectedPermissions.includes(perm);
+                            const { backgroundColor, textColor } = getPermissionColors(perm);
+                            return (
+                                <DefaultButton
+                                    key={perm}
+                                    text={perm}
+                                    onClick={() => toggleCreatePermission(perm)}
+                                    styles={{
+                                        root: {
+                                            backgroundColor: selected ? backgroundColor : 'lightgray',
+                                            color: selected ? textColor : 'black',
+                                            marginRight: 8,
+                                            borderRadius: 4,
+                                            height: 32
+                                        }
+                                    }}
+                                />
+                            );
+                        })}
+                    </Stack>
+                </Stack>
+
+                <DialogFooter>
+                    <DefaultButton onClick={closeDialog} text="Cancel" />
+                    <PrimaryButton onClick={addParticipant} text="Add Participant" styles={{ root: { backgroundColor: 'black', color: 'white' }, rootHovered: { backgroundColor: 'darkgray' } }} />
+                </DialogFooter>
             </Dialog>
-        </Card>
+        </Stack>
     );
 };
 
 export default Participants;
+


### PR DESCRIPTION
## Ticket

- [AS-004] (https://www.notion.so/code-leap/1a0298c169e6808e8934c8db74e70021?v=1a0298c169e680559dc6000c8ef737ad&p=1bb298c169e680b69a50c8f16d8df616&pm=s) [Develop UI in all current pages to change from @mui/material to @fluentUI/web-component

## Description

- Change from using MUI to FluentUI of all pages, including:
+ Closing Steps
+ Closing Meeting
+ Closing Memo
+ Tasks
+ Documents
+ Participants

## Project of change

- [ ] root
- [ ] api/
- [ ] appPackage/
- [ ] build/
- [ ] devTools/
- [ ] env/
- [ ] images/
- [ ] infra/
- [ ] public/
- [x] src/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Code style update (formatting, renaming), remove unused code, or clean up code.
- [ ] Documentation update (non-code change).
- [ ] Dependency update.
- [ ] DevOps update (CI/CD, infrastructure, etc).

## How Has This Been Tested?
Local:
![image](https://github.com/user-attachments/assets/0fd10c84-9781-453c-9055-f6a65e1dbb86)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Depend on other PRs

`N/A`